### PR TITLE
Fix UpdateUserById function

### DIFF
--- a/src/OneLoginClient.IntegrationTests/OneLoginClient.Users.Tests.cs
+++ b/src/OneLoginClient.IntegrationTests/OneLoginClient.Users.Tests.cs
@@ -76,5 +76,17 @@ namespace OneLogin.IntegrationTests
             var rolesForUser = (await _oneLoginClient.GetRolesForUser(32715399))
                 .EnsureSuccess();
         }
+
+        [Fact]
+        public async Task UpdateUserByIdTest()
+        {
+            var updateResponse = await _oneLoginClient.UpdateUserById(32715399, new UpdateUserByIdRequest
+            {
+                FirstName = "FirstNameTest" // Don't actually change it so we don't affect the integration environment
+            });
+
+            updateResponse.EnsureSuccess();
+            updateResponse.Data.Should().HaveCount(1);
+        }
     }
 }

--- a/src/OneLoginClient/OneLoginClient.Users.cs
+++ b/src/OneLoginClient/OneLoginClient.Users.cs
@@ -96,11 +96,12 @@ namespace OneLogin
         /// <summary>
         /// Updates a onelogin user account.
         /// </summary>
+        /// <param name="userId">Set to the id of the user which you want to update.</param>
         /// <param name="byIdRequest">The request object.</param>
         /// <returns></returns>
-        public async Task<GetUsersResponse> UpdateUserById(int id, UpdateUserByIdRequest byIdRequest)
+        public async Task<GetUsersResponse> UpdateUserById(int userId, UpdateUserByIdRequest byIdRequest)
         {
-            return await PutResource<GetUsersResponse>(Endpoints.ONELOGIN_USERS, byIdRequest);
+            return await PutResource<GetUsersResponse>($"{Endpoints.ONELOGIN_USERS}/{userId}", byIdRequest);
         }
 
         /// <summary>

--- a/src/OneLoginClient/OneLoginClient.cs
+++ b/src/OneLoginClient/OneLoginClient.cs
@@ -139,7 +139,10 @@ namespace OneLogin
             if (request == null) throw new ArgumentNullException(nameof(request));
             if (string.IsNullOrWhiteSpace(url)) { throw new ArgumentException(nameof(url)); }
 
-            var content = new StringContent(JsonConvert.SerializeObject(request));
+            var content = new StringContent(JsonConvert.SerializeObject(request, settings: new JsonSerializerSettings
+            {
+                NullValueHandling = NullValueHandling.Ignore
+            }));
             var httpRequest = new HttpRequestMessage
             {
                 Method = HttpMethod.Post,
@@ -162,7 +165,10 @@ namespace OneLogin
             if (request == null) throw new ArgumentNullException(nameof(request));
             if (string.IsNullOrWhiteSpace(url)) { throw new ArgumentException(nameof(url)); }
 
-            var content = new StringContent(JsonConvert.SerializeObject(request));
+            var content = new StringContent(JsonConvert.SerializeObject(request, settings: new JsonSerializerSettings
+            {
+                NullValueHandling = NullValueHandling.Ignore
+            }));
             var httpRequest = new HttpRequestMessage
             {
                 Method = HttpMethod.Put,

--- a/src/OneLoginClient/Requests/UpdateUserByIdRequest.cs
+++ b/src/OneLoginClient/Requests/UpdateUserByIdRequest.cs
@@ -124,7 +124,7 @@ namespace OneLogin.Requests
         /// Synchronized from Active Directory.
         /// </summary>
         [DataMember(Name = "state")]
-        public State State { get; set; }
+        public State? State { get; set; }
 
         /// <summary>
         /// Synchronized from Active Directory.


### PR DESCRIPTION
Hopefully you don't mind the out of the blue PR.

This PR is really just a fix for the update user id function which wasn't correctly generating the endpoint (it wasn't actually using the id). In doing that I decided to add an integration test for the function which demonstrated that it was broken for two further reasons:

1. It isn't possible to set the notes field on the freshdesk api (bug in their docs afaict)
2. You were serializing all null values into the PUT/POST requests along with default values for enums

I decided to make a straightforward fix for both by telling Json.NET to not serialize nulls and crucially making the "State" of a user a nullable enum instead of just an enum. That's obviously a breaking change but I think it's necessary or all PUT requests to a user will reset the state to 0 = unapproved!